### PR TITLE
Web Font perf: drop Roboto (#12)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     <div id="app"></div>
     <!-- built files will be auto injected -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" type="text/css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:400,600|Teko:300,400,500,600" type="text/css">
   <script src="https://use.fontawesome.com/releases/v5.0.10/js/all.js"></script>
   </body>


### PR DESCRIPTION
This is a minor change for https://github.com/google/io-demo-app/issues/12 which drops the Roboto font as we appear to be using Monserrat for body text now too.