### PR TITLE
Add support for lazy-loading offscreen images

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lighthouse": "source lighthouse/runLighthouse.sh"
   },
   "dependencies": {
+    "lazysizes": "^4.0.2",
     "material-components-web": "^0.34.1",
     "node-sass": "^4.8.3",
     "sass-loader": "^6.0.7",

--- a/src/components/DoodleSlider.vue
+++ b/src/components/DoodleSlider.vue
@@ -15,14 +15,14 @@
              slug: 'fullscreen-doodle',
              url: currentDoodle.standalone_html
           }}">
-          <img :src="currentDoodle.url" width="100%" height="100%"/>
+          <img class="lazyload" :data-src="currentDoodle.url" width="100%" height="100%"/>
         </router-link>
       </div>
     </div>
   </div>
   <div class="film-controls">
-    <mdc-button @click="index -= 1"><i class="material-icons mdc-button__icon mdc-button mdc-ripple-upgraded mdc-ripple-upgraded--foreground-activation" style="--mdc-ripple-fg-size:38.3949px; --mdc-ripple-fg-scale:2.17269; --mdc-ripple-fg-translate-start:6.98539px, 0.748938px; --mdc-ripple-fg-translate-end:12.7983px, -1.20028px;">fast_rewind</i></mdc-button>
-    <mdc-button @click="index += 1"><i class="material-icons mdc-button__icon mdc-button mdc-ripple-upgraded mdc-ripple-upgraded--foreground-activation" style="--mdc-ripple-fg-size:38.3949px; --mdc-ripple-fg-scale:2.17269; --mdc-ripple-fg-translate-start:6.98539px, 0.748938px; --mdc-ripple-fg-translate-end:12.7983px, -1.20028px;">fast_forward</i></mdc-button>
+    <button @click="index -= 1"><i class="material-icons mdc-button__icon mdc-button mdc-ripple-upgraded mdc-ripple-upgraded--foreground-activation" style="--mdc-ripple-fg-size:38.3949px; --mdc-ripple-fg-scale:2.17269; --mdc-ripple-fg-translate-start:6.98539px, 0.748938px; --mdc-ripple-fg-translate-end:12.7983px, -1.20028px;">fast_rewind</i></button>
+    <button @click="index += 1"><i class="material-icons mdc-button__icon mdc-button mdc-ripple-upgraded mdc-ripple-upgraded--foreground-activation" style="--mdc-ripple-fg-size:38.3949px; --mdc-ripple-fg-scale:2.17269; --mdc-ripple-fg-translate-start:6.98539px, 0.748938px; --mdc-ripple-fg-translate-end:12.7983px, -1.20028px;">fast_forward</i></button>
   </div>
 </div>
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,12 @@
 import Vue from 'vue'
 import App from './App'
 import router from './router'
+import attrchange from 'lazysizes/plugins/attrchange/ls.attrchange.min'
+import lazysizes from 'lazysizes'
+
+Vue.config.productionTip = false
+Vue.use(attrchange)
+Vue.use(lazysizes)
 
 Vue.config.productionTip = false
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4067,6 +4067,10 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
+lazysizes@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/lazysizes/-/lazysizes-4.0.2.tgz#2316aff5bc35ec01dcef60cb51f33f69558694a2"
+
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"


### PR DESCRIPTION
Most noticeable on the browse route

Before:
![image](https://user-images.githubusercontent.com/110953/39163382-17507702-472f-11e8-83b6-083a29df1b7d.png)

After:
![image](https://user-images.githubusercontent.com/110953/39163370-06ab0336-472f-11e8-8e57-c654675faee0.png)
