### PR TITLE
Specify page lang

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
This will give it a higher score in the Accessibility section of Lighthouse tests :-)

> `<html>` element does not have a `[lang]` attribute
> If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly.